### PR TITLE
Fixed scala pom to work with java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
@@ -19,8 +19,8 @@
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>2.11.7</version>
+            <artifactId>scala3-library_3</artifactId>
+            <version>3.6.1</version>
         </dependency>
     </dependencies>
 
@@ -35,7 +35,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.0.2</version>
+                    <version>3.12.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Added Java 21 + new scala3 library

<!-- https://mvnrepository.com/artifact/org.scala-lang/scala3-library -->
<dependency>
    <groupId>org.scala-lang</groupId>
    <artifactId>scala3-library_3</artifactId>
    <version>3.6.1</version>
</dependency>